### PR TITLE
Add `/downloads` endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+GITHUB_TOKEN=xxx
 MYSQL_ROOT_PASSWORD=xxx
 MYSQL_DB=xxx
 MYSQL_USER=xxx
@@ -6,4 +7,3 @@ MYSQL_HOST=localhost
 UVICORN_RELOAD=
 # For development:
 # UVICORN_RELOAD=--reload
-# GITHUB_TOKEN=xxx  # Not needed, just in case you're hitting the API limit during development work

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
 # Default ignores that we can extend
-ignore=D100,D102,D205,E203,E231,E731,W504,I001,W503
+ignore=D100,D102,D205,E203,E231,E731,W504,I001,W503,D200,F541,D400,D401,D403
 max-line-length=120
 exclude = .git,__pycache__,.venv,build,sdist,tests/**,examples/**

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Intellij IDE
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,4 @@ repos:
         require_serial: true
         additional_dependencies:
           - mypy
+          - types-requests

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Code for [api.multiqc.info](https://api.multiqc.info), providing run-time inform
 ## Introduction
 
 The API is a simple tool to provide a metadata endpoint for MultiQC runs.
-There is currently a single endpoint that is used - `/version`.
+Currently, there are the following endpoints that are used:
 
-The `/version` endpoint returns:
+### `/version`
 
 - Information about the latest available release
   - MultiQC uses this to print a log message advising if the current version is out of date, with information about how to upgrade.
@@ -17,6 +17,15 @@ The `/version` endpoint returns:
 - _[Planned]_: Module-specific warnings
   - Warnings scoped to module and MultiQC version
   - Will allow MultiQC to notify end users via the log if the module that they are running has serious bugs or errors.
+
+### `/downloads`
+
+- MultiQC package downloads across multiple sources, and, when available, different versions:
+  - [PyPI](https://pypi.org/project/multiqc) (additionally, split by version)
+  - [BioConda](https://bioconda.github.io/recipes/multiqc) (additionally, split by version)
+  - [DockerHub](https://hub.docker.com/r/ewels/multiqc)
+  - [GitHub clones](https://github.com/ewels/MultiQC/graphs/traffic)
+  - [BioContainers (AWS mirror)](https://api.us-east-1.gallery.ecr.aws/getRepositoryCatalogData)
 
 ## Logged metrics
 

--- a/app/downloads.py
+++ b/app/downloads.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+
+"""
+Fetch the MultiQC package download numbers from various sources.
+
+Assumes GITHUB_TOKEN is set in the environment.
+"""
+
+import json
+import logging
+import os
+from collections import Counter
+
+import packaging.version
+import requests
+
+logging.basicConfig(level=logging.INFO)
+
+
+def download_stats() -> str:
+    """
+    Fetch the MultiQC package download numbers from various sources and return them
+    as a JSON string.
+    """
+    stats: dict[str, int | None | dict[str, int]] = {}
+    stats |= pypi_stats()
+    stats |= bioconda_stats()
+    stats |= github_clones_stats()
+    stats |= github_releases_stats()
+    stats |= dockerhub_stats()
+    stats |= biocontainers_stats()
+    return json.dumps(stats, indent=2, sort_keys=True)
+
+
+def pypi_stats() -> dict[str, int | None | dict[str, int]]:
+    """
+    Download count from [PyPI](https://pypi.org/project/multiqc), also split by version.
+    """
+    pepy_url = "https://api.pepy.tech/api/v2/projects/multiqc"
+
+    total_downloads = None
+    downloads_counter: Counter[str] = Counter()
+
+    # Fetch download count from pepy.tech
+    response = requests.get(pepy_url)
+    if response.status_code == 200:
+        data = json.loads(response.text)
+        total_downloads = data["total_downloads"]
+        for date, date_downloads_by_version in data["downloads"].items():
+            for version, downloads in date_downloads_by_version.items():
+                downloads_counter[version] += downloads
+    else:
+        logging.error("Failed to fetch data from pepy.tech")
+
+    downloads_by_version: dict[str, int] = {str(packaging.version.parse(k)): v for k, v in downloads_counter.items()}
+    return {
+        "pypi": total_downloads,
+        "pypi_by_version": downloads_by_version,
+    }
+
+
+def bioconda_stats() -> dict[str, int | None | dict[str, int]]:
+    """
+    Download count from [BioConda](https://bioconda.github.io/recipes/multiqc),
+    also split by version.
+    """
+    url = "https://raw.githubusercontent.com/bioconda/bioconda-plots/main/plots/multiqc/versions.json"
+    # [{"date":"2023-09-05","total":15949,"delta":18,"version":"1.10.1"}, ...
+
+    downloads_by_version: dict[str, int] = dict()
+
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = json.loads(response.text)
+        downloads_by_version = Counter()
+        for version in data:
+            downloads_by_version[version["version"]] = version["total"]
+    else:
+        logging.error("Failed to fetch data from bioconda")
+
+    downloads_by_version = {str(packaging.version.parse(k)): v for k, v in downloads_by_version.items()}
+    return {
+        "bioconda": sum(downloads_by_version.values()),
+        "bioconda_by_version": downloads_by_version,
+    }
+
+
+def github_clones_stats() -> dict[str, int | None]:
+    """
+    Number of [GitHub clones](https://github.com/ewels/MultiQC/graphs/traffic).
+    """
+    github_token = os.environ.get("GITHUB_TOKEN")
+    url = "https://api.github.com/repos/ewels/MultiQC/traffic/clones"
+    headers = {"Authorization": f"token {github_token}"}
+
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        github_data = json.loads(response.text)
+        clone_count = github_data.get("count", 0)
+    else:
+        logging.error(f"Failed to fetch data from GitHub, status code: {response.status_code}, url: {url}")
+        clone_count = None
+
+    return {"github_clones": clone_count}
+
+
+def github_releases_stats() -> dict[str, int | None | dict[str, int]]:
+    """
+    Number of [GitHub releases](https://github.com/ewels/MultiQC/releases). Currently
+    not working properly, returning information about ancient releases only.
+    """
+    github_token = os.environ.get("GITHUB_TOKEN")
+    url = "https://api.github.com/repos/ewels/MultiQC/releases"
+    headers = {"Authorization": f"token {github_token}"}
+
+    downloads_counter: Counter[str] = Counter()
+
+    response = requests.get(url, headers=headers)
+    if response.status_code == 200:
+        data = json.loads(response.text)
+        for release in data:
+            version = packaging.version.parse(release["tag_name"])
+            for asset in release["assets"]:
+                downloads_counter[str(version)] += asset["download_count"]
+    else:
+        logging.error(f"Failed to fetch release data from GitHub, status code: {response.status_code}, url: {url}")
+
+    return {
+        "github_releases": sum(downloads_counter.values()),
+        "github_releases_by_version": dict(downloads_counter),
+    }
+
+
+def _fetch_dockerhub_count(repo: str) -> int | None:
+    url = f"https://hub.docker.com/v2/repositories/{repo}"
+    response = requests.get(url)
+    if response.status_code != 200:
+        logging.error(f"Failed to fetch data from DockerHub, status code: {response.status_code}, url: {url}")
+        return None
+    data = json.loads(response.text)
+    return data.get("pull_count", 0)
+
+
+def _fetch_quay_count(repo: str) -> int | None:
+    url = f"https://quay.io/api/v1/repository/{repo}".strip("/")
+    response = requests.get(url)
+    if response.status_code != 200:
+        logging.error(f"Failed to fetch data from Quay.io, status code: {response.status_code}, url: {url}")
+        return None
+    data = json.loads(response.text)
+    return data.get("pull_count", 0)
+
+
+def dockerhub_stats() -> dict[str, int | None]:
+    """
+    Number of [DockerHub](https://hub.docker.com/r/ewels/multiqc) pulls.
+    """
+    return {"dockerhub": _fetch_dockerhub_count("ewels/multiqc/")}
+
+
+def _biocontainers_aws() -> int | None:
+    url = "https://api.us-east-1.gallery.ecr.aws/getRepositoryCatalogData"
+    headers = {"Content-Type": "application/json"}
+    data = {"registryAliasName": "biocontainers", "repositoryName": "multiqc"}
+    response = requests.post(url, headers=headers, json=data)
+
+    if response.status_code != 200:
+        logging.error(f"Failed to fetch data from {url}:", response.status_code, response.text)
+        return None
+
+    try:
+        count = response.json()["insightData"]["downloadCount"]
+    except IndexError:
+        logging.error(f"Cannot extract insightData/downloadCount from response:", response.text)
+        return None
+    return count
+
+
+def biocontainers_stats() -> dict[str, int | None]:
+    """
+    Number of BioContainers pulls, currently only supported for the images hosted on
+    the [AWS mirror](https://api.us-east-1.gallery.ecr.aws/getRepositoryCatalogData)
+    """
+    out = {
+        "biocontainers_dockerhub": _fetch_dockerhub_count("biocontainers/multiqc/"),
+        "biocontainers_quay": _fetch_quay_count("biocontainers/multiqc/"),
+        "biocontainers_aws": _biocontainers_aws(),
+    }
+    out["biocontainers"] = sum(v for v in out.values() if v is not None)
+    return out
+
+
+if __name__ == "__main__":
+    print(download_stats())

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from github import Github
 from plotly.graph_objs import Layout
 
 from . import __version__, db, models
+from .downloads import download_stats
 
 
 def get_latest_release() -> models.LatestRelease:
@@ -55,6 +56,15 @@ async def index(background_tasks: BackgroundTasks):
             {"path": route.path, "name": route.name} for route in app.routes if route.name != "swagger_ui_redirect"
         ],
     }
+
+
+@app.get("/downloads")
+async def downloads():
+    """
+    MultiQC package downloads across difference sources, and when available,
+    different versions.
+    """
+    return download_stats()
 
 
 @app.get("/version")


### PR DESCRIPTION
Implements a https://api.multiqc.info/downloads endpoint that returns the number of downloads of the MultiQC package across different sources.

See this issue https://github.com/seqeralabs/devops-backlog/issues/276 for discussion.

Needs a `GITHUB_TOKEN` env var to be set (the `gho_*` one, returned by `gh auth token`).

Currently, it directly queries the repositories APIs on request. Might think of additional layer for throttling, or caching, or adding into a DB on a schedule and returning the results stored in the DB. On the other hand, the endpoint is going to be called from the internal infra on a schedule, so perhaps it will be taken care of on another level already 🤔 