### PR TITLE
Summarise visits by minute; buffer in memory and in CSV before DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dmypy.json
 .idea/
 
 .DS_Store
+
+visits.csv

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,7 @@
 """api.multiqc.info: Providing run-time information about available updates."""
 
 __version__ = "0.1.0.dev0"
+
+from dotenv import load_dotenv
+
+load_dotenv()

--- a/app/db.py
+++ b/app/db.py
@@ -12,30 +12,23 @@ engine = create_engine(sql_url)
 
 class Visits(SQLModel, table=True):  # type: ignore # mypy doesn't like this, not sure why
     """
-    Table to record per-minute visit summaries
+    Table to record per-minute visit summaries. Start is a primary key,
+    and start and end are both indexed.
     """
 
-    id: int | None = Field(default=None, primary_key=True)
-    start: datetime.datetime | None = None
-    end: datetime.datetime | None = None
-    count: int = 0
-    version_multiqc: str | None = None
-    version_python: str | None = None
-    operating_system: str | None = None
-    installation_method: str | None = None
-    ci_environment: str | None = None
+    start: datetime.datetime = Field(primary_key=True)
+    end: datetime.datetime = Field(primary_key=True)
+    count: int
+    version_multiqc: str = Field(index=True)
+    version_python: str = Field(default=None, index=True)
+    operating_system: str = Field(default=None, index=True)
+    installation_method: str = Field(default=None, index=True)
+    ci_environment: str = Field(default=None, index=True)
 
 
 def create_db_and_tables() -> None:
     """Create the database and tables if they don't exist."""
     SQLModel.metadata.create_all(engine)
-
-
-# def add_visit(visit: Visits) -> None:
-#     """Add a visit to the database."""
-#     with Session(engine) as session:
-#         session.add(visit)
-#         session.commit()
 
 
 def get_visits(

--- a/app/db.py
+++ b/app/db.py
@@ -12,8 +12,9 @@ engine = create_engine(sql_url)
 
 class Visits(SQLModel, table=True):  # type: ignore # mypy doesn't like this, not sure why
     """
-    Table to record per-minute visit summaries. Start is a primary key,
-    and start and end are both indexed.
+    Table to record per-minute visit summaries.
+    
+    Start is a primary key, and start and end are both indexed.
     """
 
     start: datetime.datetime = Field(primary_key=True)

--- a/app/db.py
+++ b/app/db.py
@@ -1,24 +1,29 @@
 """Functions to interact with the database."""
+import os
 
 import datetime
-from os import getenv
 
 from sqlmodel import create_engine, Field, select, Session, SQLModel
 
-sql_url = getenv("DATABASE_URL")
+sql_url = os.getenv("DATABASE_URL")
+assert sql_url is not None, sql_url
 engine = create_engine(sql_url)
 
 
-class Visit(SQLModel, table=True):  # type: ignore # mypy doesn't like this, not sure why
-    """Table to record raw individual visits to the version endpoint."""
+class Visits(SQLModel, table=True):  # type: ignore # mypy doesn't like this, not sure why
+    """
+    Table to record per-minute visit summaries
+    """
 
     id: int | None = Field(default=None, primary_key=True)
+    start: datetime.datetime | None = None
+    end: datetime.datetime | None = None
+    count: int = 0
     version_multiqc: str | None = None
     version_python: str | None = None
     operating_system: str | None = None
     installation_method: str | None = None
     ci_environment: str | None = None
-    called_at: datetime.datetime | None = Field(default_factory=datetime.datetime.utcnow, nullable=False)
 
 
 def create_db_and_tables() -> None:
@@ -26,27 +31,27 @@ def create_db_and_tables() -> None:
     SQLModel.metadata.create_all(engine)
 
 
-def add_visit(visit: Visit) -> None:
-    """Add a visit to the database."""
-    with Session(engine) as session:
-        session.add(visit)
-        session.commit()
+# def add_visit(visit: Visits) -> None:
+#     """Add a visit to the database."""
+#     with Session(engine) as session:
+#         session.add(visit)
+#         session.commit()
 
 
 def get_visits(
     start: datetime.datetime | None = None,
     end: datetime.datetime | None = None,
     limit: int | None = None,
-) -> list[Visit]:
-    """Return list of raw visits from the DB."""
+) -> list[Visits]:
+    """Return list of per-minute visit summary from the DB."""
     with Session(engine) as session:
-        statement = select(Visit)
+        statement = select(Visits)
         if start:
             # Ignore type because Visit.called_at can be None for default value
-            statement.where(Visit.called_at > start)  # type: ignore
+            statement.where(Visits.start >= start)  # type: ignore
         if end:
-            statement.where(Visit.called_at < end)  # type: ignore
+            statement.where(Visits.end <= end)  # type: ignore
         if limit:
             statement.limit(limit)
-        statement.order_by(Visit.called_at.desc())  # type: ignore
+        statement.order_by(Visits.start.desc())  # type: ignore
         return session.exec(statement).all()

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,12 @@
+import csv
 import datetime
+import logging
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from threading import Lock
+
+import uvicorn
 from enum import Enum
 from os import getenv
 
@@ -6,10 +14,23 @@ import pandas as pd
 import plotly.express as px
 from fastapi import BackgroundTasks, FastAPI
 from fastapi.responses import HTMLResponse, PlainTextResponse, Response
+from fastapi_utilities import repeat_every
 from github import Github
 from plotly.graph_objs import Layout
 
-from . import __version__, db, models
+from app import __version__, db, models
+from app.db import engine
+
+
+app = FastAPI(
+    title="MultiQC API",
+    description="MultiQC API service, providing run-time information about available updates.",
+    version=__version__,
+    license_info={
+        "name": "Source code available under the MIT Licence",
+        "url": "https://github.com/MultiQC/api.multiqc.info/blob/main/LICENSE",
+    },
+)
 
 
 def get_latest_release() -> models.LatestRelease:
@@ -24,22 +45,102 @@ def get_latest_release() -> models.LatestRelease:
     )
 
 
-app = FastAPI(
-    title="MultiQC API",
-    description="MultiQC API service, providing run-time information about available updates.",
-    version=__version__,
-    license_info={
-        "name": "Source code available under the MIT Licence",
-        "url": "https://github.com/MultiQC/api.multiqc.info/blob/main/LICENSE",
-    },
-)
+app.latest_release = get_latest_release()
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
-@app.on_event("startup")
-def on_startup():
-    """Initialise the DB and tables on server startup."""
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Initialise the DB and tables on server startup
     db.create_db_and_tables()
+    # Sync latest version tag using GitHub API
     app.latest_release = get_latest_release()
+    yield
+
+
+@repeat_every(seconds=15 * 60)  # every 15 minutes
+def update_version():
+    """Sync latest version tag using GitHub API"""
+    app.latest_release = get_latest_release()
+
+
+# Fields to store per visit
+fieldnames = [
+    "version_multiqc",
+    "version_python",
+    "operating_system",
+    "installation_method",
+    "ci_environment",
+]
+
+# Thread-safe in-memory buffer to accumulate recent visits before writing to the CSV file
+visit_data = []
+visit_data_lock = Lock()
+
+
+@app.get("/version")  # log a visit
+async def version(
+    version_multiqc: str | None = None,
+    version_python: str | None = None,
+    operating_system: str | None = None,
+    installation_method: str | None = None,
+    ci_environment: str | None = None,
+):
+    """
+    Endpoint for MultiQC that returns the latest release, and logs
+    the visit along with basic user environment detail.
+    """
+    with visit_data_lock:
+        visit_data.append(
+            {
+                "timestamp": datetime.datetime.now().isoformat(),
+                "version_multiqc": version_multiqc,
+                "version_python": version_python,
+                "operating_system": operating_system,
+                "installation_method": installation_method,
+                "ci_environment": ci_environment,
+            }
+        )
+    return models.VersionResponse(latest_release=app.latest_release)
+
+
+# Path to a buffer CSV file to persist recent visits before dumping to the database
+# In the same folder as this script
+CSV_FILE_PATH = Path(__file__).parent / "visits.csv"
+
+
+@repeat_every(seconds=10)  # every 10 seconds
+async def persist_visits():
+    """Write in-memory visits to a CSV file"""
+    global visit_data
+    with visit_data_lock:
+        if visit_data:
+            logger.debug(f"Persisting {len(visit_data)} visits to CSV {CSV_FILE_PATH}")
+            with open(CSV_FILE_PATH, mode="a") as file:
+                writer = csv.DictWriter(file, fieldnames=["timestamp"] + fieldnames)
+                for row in visit_data:
+                    writer.writerow(row)
+            visit_data = []
+
+
+@repeat_every(seconds=60 * 60 * 1)  # every hour
+async def summarize_visits():
+    with visit_data_lock:
+        df = pd.read_csv(CSV_FILE_PATH, sep=",", names=["timestamp"] + fieldnames)
+        df["start"] = pd.to_datetime(df["timestamp"])
+        df["end"] = df["start"] + pd.to_timedelta("1min")
+        df["start"] = df["start"].dt.strftime("%Y-%m-%d %H:%M")
+        df["end"] = df["end"].dt.strftime("%Y-%m-%d %H:%M")
+        df = df.drop(columns=["timestamp"])
+        # replace nan with "Unknown"
+        df = df.fillna("Unknown")  # df.groupby will fail if there are NaNs
+        # Summarize visits per user per minute
+        minute_summary = df.groupby(["start", "end"] + fieldnames).size().reset_index(name="count")
+        logger.debug(f"Summarizing {len(df)} visits in {CSV_FILE_PATH} and writing {len(minute_summary)} rows to DB")
+        minute_summary.to_sql("visits", con=engine, if_exists="append", index=False)
 
 
 @app.get("/")
@@ -69,29 +170,6 @@ async def downloads():
     return {}
 
 
-@app.get("/version")
-async def version(
-    background_tasks: BackgroundTasks,
-    version_multiqc: str | None = None,
-    version_python: str | None = None,
-    operating_system: str | None = None,
-    installation_method: str | None = None,
-    ci_environment: str | None = None,
-):
-    """Endpoint for MultiQC that returns the latest release, plus bonus info."""
-    background_tasks.add_task(
-        db.add_visit,
-        db.Visit(
-            version_multiqc=version_multiqc,
-            version_python=version_python,
-            operating_system=operating_system,
-            installation_method=installation_method,
-            ci_environment=ci_environment,
-        ),
-    )
-    return models.VersionResponse(latest_release=app.latest_release)
-
-
 @app.get("/version.php", response_class=PlainTextResponse)
 async def version_legacy(background_tasks: BackgroundTasks, v: str | None = None):
     """
@@ -100,7 +178,13 @@ async def version_legacy(background_tasks: BackgroundTasks, v: str | None = None
     Accessed by MultiQC versions 1.14 and earlier,
     after being redirected to by https://multiqc.info/version.php
     """
-    background_tasks.add_task(db.add_visit, db.Visit(version_multiqc=v))
+    with visit_data_lock:
+        visit_data.append(
+            {
+                "timestamp": datetime.datetime.now().isoformat(),
+                "version_multiqc": v,
+            }
+        )
     return app.latest_release.version
 
 
@@ -127,7 +211,7 @@ class PlotlyTemplates(str, Enum):
 
 
 @app.get("/plot_usage")
-async def usage_raw(
+async def plot_usage(
     categories: models.UsageCategory | None = None,
     interval: models.IntervalTypes = models.IntervalTypes.D,
     start: datetime.datetime | None = None,
@@ -139,6 +223,8 @@ async def usage_raw(
     """Plot usage metrics."""
     # Get visit data
     visits = db.get_visits(start=start, end=end, limit=limit)
+    if not visits:
+        return Response(status_code=204)
     df = pd.DataFrame.from_records([i.dict() for i in visits])
     df.fillna("Unknown", inplace=True)
     legend_title_text = models.usage_category_nicenames[categories] if categories else None
@@ -148,15 +234,17 @@ async def usage_raw(
         categories = models.UsageCategory[categories.name.replace("_simple", "")]
         df[categories.name] = df[categories.name].str.replace(r"^v?(\d+\.\d+).+", lambda m: m.group(1), regex=True)
 
-    # Plot
+    # Plot histogram of df.count per interval from df.start
     fig = px.histogram(
         df,
-        x=df["called_at"].dt.to_period(interval.name).astype("datetime64[M]"),
-        color=categories,
-        title="MultiQC usage",
+        x="start",
+        y="count",
+        color=categories.name if categories else None,
+        title="Usage per version per week",
     )
-    fig.update_traces(xbins_size=models.interval_types_plotly[interval])
-    fig.update_layout(legend_title_text=legend_title_text)
+    fig.update_layout(
+        legend_title_text=legend_title_text,
+    )
     return plotly_image_response(plotly_to_image(fig, format, template), format)
 
 
@@ -202,3 +290,7 @@ def plotly_image_response(plot, format: PlotlyImageFormats = PlotlyImageFormats.
     elif format == "png":
         return Response(content=plot, media_type="image/png")
     return Response(content=plot)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/app/main.py
+++ b/app/main.py
@@ -165,6 +165,7 @@ async def summarize_visits():
         return Response(status_code=200)
 
 
+# Add a /summarize endpoint to trigger the summarize logic manually available only when developing
 if os.getenv("ENVIRONMENT") == "DEV":
 
     @app.get("/summarize")
@@ -177,21 +178,8 @@ if os.getenv("ENVIRONMENT") == "DEV":
             raise HTTPException(status_code=500, detail=str(e))
 
 
-@app.get("/")
-async def index(background_tasks: BackgroundTasks):
-    """
-    Root endpoint for the API.
-
-    Returns a list of available endpoints.
-    """
-    return {
-        "message": "Welcome to the MultiQC service API",
-        "available_endpoints": [
-            {"path": route.path, "name": route.name} for route in app.routes if route.name != "swagger_ui_redirect"
-        ],
-    }
-
-
+@app.on_event("startup")
+@repeat_every(seconds=60 * 60 * 1)  # daily
 @app.get("/downloads")
 async def downloads():
     """
@@ -220,6 +208,21 @@ async def version_legacy(background_tasks: BackgroundTasks, v: str | None = None
             }
         )
     return app.latest_release.version
+
+
+@app.get("/")
+async def index(background_tasks: BackgroundTasks):
+    """
+    Root endpoint for the API.
+
+    Returns a list of available endpoints.
+    """
+    return {
+        "message": "Welcome to the MultiQC service API",
+        "available_endpoints": [
+            {"path": route.path, "name": route.name} for route in app.routes if route.name != "swagger_ui_redirect"
+        ],
+    }
 
 
 class PlotlyImageFormats(str, Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,9 @@
-[tool.black]
+[tool.ruff]
 line-length = 120
-target-version = ['py310']
-
-[tool.isort]
-line_length = 120
-multi_line_output = 3
-force_alphabetical_sort_within_sections = "True"
-force_sort_within_sections = "False"
-sections = [
-    "FUTURE",
-    "STDLIB",
-    "THIRDPARTY",
-    "FIRSTPARTY",
-    "LOCALFOLDER",
-]
-profile = "black"
+target-version = "py312"
+ignore-init-module-imports = true
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 ignore_missing_imports = "True"
 scripts_are_modules = "True"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
+fastapi-utilities
 kaleido
 pandas
 plotly


### PR DESCRIPTION
- [x] Instead of storing individual visits, summarize them by minute by attributes
- [x] Rename `Visit` to `Visits` and use fields `start`, `end`, `count` instead of `timestamp`
- [x] Instead of directly pushing visits to DB, buffer them in memory, and every 10 sec persist in a CSV file, and daily summarize and persist in the DB
- [x] Remove visits.csv once DB is successfully updated
- [x] Switch to ruff for linting