### PR TITLE
Add shutdown handler

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -298,7 +298,9 @@ async def shutdown_event():
     """
     Summarize when the app receives a shutdown signal.
     """
+    logger.info("Shutdown called, summarizing visits...")
     _summarize_visits()
+    logger.info("Complete, now ready to shut down")
 
 
 def _update_download_stats():

--- a/app/main.py
+++ b/app/main.py
@@ -293,6 +293,14 @@ async def summarize_visits():
     return _summarize_visits()
 
 
+@app.on_event("shutdown")
+async def shutdown_event():
+    """
+    Summarize when the app receives a shutdown signal.
+    """
+    _summarize_visits()
+
+
 def _update_download_stats():
     """
     Update the daily download statistics in the database


### PR DESCRIPTION
Persist data on SIGTERM to avoid losing data on restarts.

Works assuming the default `terminationGracePeriodSeconds: 30` period.