### PR TITLE
Add `is_notebook` and `interactive_function_name` visit field

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,4 +1,5 @@
 """Functions to interact with the database."""
+
 from typing import Optional, Sequence
 
 import os
@@ -34,6 +35,8 @@ class VisitStats(SQLModel, table=True):
     is_singularity: bool
     is_conda: bool
     is_ci: bool
+    is_notebook: bool
+    interactive_function_name: Optional[str]
     count: int
 
 
@@ -129,4 +132,3 @@ def insert_download_stats(df: pd.DataFrame) -> pd.DataFrame:
                 session.add(new_entry)
         session.commit()
     return df
-

--- a/app/main.py
+++ b/app/main.py
@@ -89,6 +89,8 @@ visit_fieldnames = [
     "is_singularity",
     "is_conda",
     "is_ci",
+    "is_notebook",
+    "interactive_function_name",
 ]
 
 # Thread-safe in-memory buffer to accumulate recent visits before writing to the CSV file
@@ -106,6 +108,8 @@ async def version(
     is_singularity: str = "",
     is_conda: str = "",
     is_ci: str = "",
+    is_notebook: str = "",
+    interactive_function_name: str = "",
 ):
     """
     Endpoint for MultiQC that returns the latest release, and logs
@@ -121,6 +125,8 @@ async def version(
         is_singularity=is_singularity,
         is_conda=is_conda,
         is_ci=is_ci,
+        is_notebook=is_notebook,
+        interactive_function_name=interactive_function_name,
     )
     return models.VersionResponse(latest_release=app.latest_release)
 
@@ -149,6 +155,8 @@ def _log_visit(
     is_singularity: str = "",
     is_conda: str = "",
     is_ci: str = "",
+    is_notebook: str = "",
+    interactive_function_name: str = "",
 ):
     global visit_buffer
     with visit_buffer_lock:
@@ -162,6 +170,8 @@ def _log_visit(
                 "is_singularity": is_singularity,
                 "is_conda": is_conda,
                 "is_ci": is_ci,
+                "is_notebook": is_notebook,
+                "interactive_function_name": interactive_function_name,
             }
         )
         logger.debug(f"Logged visit, total visits in buffer: {len(visit_buffer)}")
@@ -252,6 +262,8 @@ def _summarize_visits(interval="5min") -> Response:
         df["is_singularity"] = df["is_singularity"].apply(strtobool)
         df["is_conda"] = df["is_conda"].apply(strtobool)
         df["is_ci"] = df["is_ci"].apply(strtobool)
+        df["is_notebook"] = df["is_notebook"].apply(strtobool)
+        df["interactive_function_name"] = df["interactive_function_name"].astype(str)
         df = df.drop(columns=["timestamp"])
 
         # Summarize visits per user per time interval
@@ -409,6 +421,8 @@ async def version_legacy(background_tasks: BackgroundTasks, v: str = ""):
         is_singularity="",
         is_conda="",
         is_ci="",
+        is_notebook="",
+        interactive_function_name="",
     )
     return app.latest_release.version
 

--- a/app/models.py
+++ b/app/models.py
@@ -66,6 +66,8 @@ class UsageCategory(str, Enum):
     is_singularity = "is_singularity"
     is_conda = "is_conda"
     is_ci = "is_ci"
+    is_notebook = "is_notebook"
+    interactive_function_name = "interactive_function_name"
 
 
 usage_category_nice_names = dict(
@@ -78,4 +80,6 @@ usage_category_nice_names = dict(
     is_singularity="Singularity",
     is_conda="Conda",
     is_ci="CI environment",
+    is_notebook="Notebook",
+    interactive_function_name="Interactive function",
 )


### PR DESCRIPTION
Tracking "visits" of interactive calls as well

Probably will remove in favour of tracking on `import multiqc`